### PR TITLE
Vectorized the util calculations

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 
 from hparam import hparam as hp
 
-def get_centroids(embeddings):
+def get_centroids_prior(embeddings):
     centroids = []
     for speaker in embeddings:
         centroid = 0
@@ -22,6 +22,10 @@ def get_centroids(embeddings):
         centroid = centroid/len(speaker)
         centroids.append(centroid)
     centroids = torch.stack(centroids)
+    return centroids
+
+def get_centroids(embeddings):
+    centroids = embeddings.mean(dim=1)
     return centroids
 
 def get_centroid(embeddings, speaker_num, utterance_num):
@@ -33,7 +37,27 @@ def get_centroid(embeddings, speaker_num, utterance_num):
     centroid = centroid/(len(embeddings[speaker_num])-1)
     return centroid
 
-def get_cossim(embeddings, centroids):
+def get_utterance_centroids(embeddings):
+    """
+    Returns the centroids for each utterance of a speaker, where
+    the utterance centroid is the speaker centroid without considering
+    this utterance
+
+    Shape of embeddings should be:
+        (speaker_ct, utterance_per_speaker_ct, embedding_size)
+    """
+    sum_centroids = embeddings.sum(dim=1)
+    # we want to subtract out each utterance, prior to calculating the
+    # the utterance centroid
+    sum_centroids = sum_centroids.reshape(
+        sum_centroids.shape[0], 1, sum_centroids.shape[-1]
+    )
+    # we want the mean but not including the utterance itself, so -1
+    num_utterances = embeddings.shape[1] - 1
+    centroids = (sum_centroids - embeddings) / num_utterances
+    return centroids
+
+def get_cossim_prior(embeddings, centroids):
     # Calculates cosine similarity matrix. Requires (N, M, feature) input
     cossim = torch.zeros(embeddings.size(0),embeddings.size(1),centroids.size(0))
     for speaker_num, speaker in enumerate(embeddings):
@@ -45,13 +69,66 @@ def get_cossim(embeddings, centroids):
                 cossim[speaker_num][utterance_num][centroid_num] = output
     return cossim
 
-def calc_loss(sim_matrix):
+def get_cossim(embeddings, centroids):
+    # number of utterances per speaker
+    num_utterances = embeddings.shape[1]
+    utterance_centroids = get_utterance_centroids(embeddings)
+
+    # flatten the embeddings and utterance centroids to just utterance,
+    # so we can do cosine similarity
+    utterance_centroids_flat = utterance_centroids.view(
+        utterance_centroids.shape[0] * utterance_centroids.shape[1],
+        -1
+    )
+    embeddings_flat = embeddings.view(
+        embeddings.shape[0] * num_utterances,
+        -1
+    )
+    # the cosine distance between utterance and the associated centroids
+    # for that utterance
+    # this is each speaker's utterances against his own centroid, but each
+    # comparison centroid has the current utterance removed
+    cos_same = F.cosine_similarity(embeddings_flat, utterance_centroids_flat)
+
+    # now we get the cosine distance between each utterance and the other speakers'
+    # centroids
+    # to do so requires comparing each utterance to each centroid. To keep the
+    # operation fast, we vectorize by using matrices L (embeddings) and
+    # R (centroids) where L has each utterance repeated sequentially for all
+    # comparisons and R has the entire centroids frame repeated for each utterance
+    centroids_expand = centroids.repeat((num_utterances * embeddings.shape[0], 1))
+    embeddings_expand = embeddings_flat.unsqueeze(1).repeat(1, embeddings.shape[0], 1)
+    embeddings_expand = embeddings_expand.view(
+        embeddings_expand.shape[0] * embeddings_expand.shape[1],
+        embeddings_expand.shape[-1]
+    )
+    cos_diff = F.cosine_similarity(embeddings_expand, centroids_expand)
+    cos_diff = cos_diff.view(
+        embeddings.size(0),
+        num_utterances,
+        centroids.size(0)
+    )
+    # assign the cosine distance for same speakers to the proper idx
+    same_idx = list(range(embeddings.size(0)))
+    cos_diff[same_idx, :, same_idx] = cos_same.view(embeddings.shape[0], num_utterances)
+    cos_diff = cos_diff + 1e-6
+    return cos_diff
+
+def calc_loss_prior(sim_matrix):
     # Calculates loss from (N, M, K) similarity matrix
     per_embedding_loss = torch.zeros(sim_matrix.size(0), sim_matrix.size(1))
     for j in range(len(sim_matrix)):
         for i in range(sim_matrix.size(1)):
             per_embedding_loss[j][i] = -(sim_matrix[j][i][j] - ((torch.exp(sim_matrix[j][i]).sum()+1e-6).log_()))
     loss = per_embedding_loss.sum()    
+    return loss, per_embedding_loss
+
+def calc_loss(sim_matrix):
+    same_idx = list(range(sim_matrix.size(0)))
+    pos = sim_matrix[same_idx, :, same_idx]
+    neg = (torch.exp(sim_matrix).sum(dim=2) + 1e-6).log_()
+    per_embedding_loss = -1 * (pos - neg)
+    loss = per_embedding_loss.sum()
     return loss, per_embedding_loss
 
 def normalize_0_1(values, max_value, min_value):


### PR DESCRIPTION
I've left in the original functions, appending _prior to the name for testing. I've tested various inputs w/ the new implementations and the outputs match exactly.

Getting rid of the for loops results in a considerable speedup:

From testing using %timeit in ipython:

get_centroids:
before: 266 µs ± 13.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
after: 4.5 µs ± 72.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

get_cossim:
before: 20.3 ms ± 111 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
after: 398 µs ± 2.64 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

calc_loss:
before: 1.12 ms ± 9.78 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
after: 66.8 µs ± 1.09 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)